### PR TITLE
Fix linux binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,7 +153,7 @@ jobs:
 
   upload_assets_linux:
     needs: create_github_release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
 
@@ -186,14 +186,6 @@ jobs:
           wget -q https://musl.cc/aarch64-linux-musl-cross.tgz
           tar -xf aarch64-linux-musl-cross.tgz
           echo "$(pwd)/aarch64-linux-musl-cross/bin" >> $GITHUB_PATH
-
-      - name: Install Android NDK
-        run: echo "y" | sudo ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;25.2.9519653"
-
-      - name: Set up Android NDK environment
-        run: |
-          echo "ANDROID_NDK_HOME=${ANDROID_HOME}/ndk/25.2.9519653" >> $GITHUB_ENV
-          echo "ANDROID_NDK=${ANDROID_HOME}/ndk/25.2.9519653" >> $GITHUB_ENV
 
       - name: Build and tarball
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.1.10
+
+- Fix binaries for Ubuntu
+
 # v0.1.9
 
 - Set +x permissions on macOS + linux binaries during build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "fta"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "clap",
  "env_logger",
@@ -313,7 +313,7 @@ dependencies = [
 
 [[package]]
 name = "fta-wasm"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "fta",
  "serde_json",

--- a/crates/fta-wasm/Cargo.toml
+++ b/crates/fta-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fta-wasm"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 
 [lib]

--- a/crates/fta/Cargo.toml
+++ b/crates/fta/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fta"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Fast TypeScript Analyzer"

--- a/packages/fta/README.md
+++ b/packages/fta/README.md
@@ -53,10 +53,6 @@ Example output against the Redux project:
 
 1. To call FTA from a script, install `fta-cli` as a dependency and call it:
 
-<!-- - As a script that prints out information about your project (_Recommended_)
-  - You can optionally set `score_cap` to require a minimum quality level in your CI (See [Configuration](https://ftaproject.dev/docs/configuration))
-- From code so that you can programmatically interact with the output -->
-
 ```bash
 yarn add fta-cli
 # or
@@ -67,7 +63,7 @@ pnpm install fta-cli
 
 2. Call `fta` from a `package.json` script:
 
-```
+```json
 "scripts": {
   "fta": "fta src"
 }
@@ -79,6 +75,8 @@ You can also call `fta-cli` from code:
 
 ```javascript
 import { runFta } from "fta-cli";
+// CommonJS alternative:
+// const { runFta } = require("fta-cli");
 
 // Print the standard ascii table output
 const standardOutput = runFta("path/to/project");

--- a/packages/fta/index.js
+++ b/packages/fta/index.js
@@ -25,11 +25,15 @@ function getBinaryPath() {
       }
     case "linux":
       if (architecture === "x64") {
-        return path.join(targetDirectory, "x86_64-unknown-linux-gnu");
+        return path.join(targetDirectory, "x86_64-unknown-linux-gnu", "fta");
       } else if (architecture === "arm64") {
-        return path.join(targetDirectory, "aarch64-unknown-linux-gnu");
+        return path.join(targetDirectory, "aarch64-unknown-linux-gnu", "fta");
       } else if (architecture === "arm") {
-        return path.join(targetDirectory, "armv7-unknown-linux-gnueabihf");
+        return path.join(
+          targetDirectory,
+          "armv7-unknown-linux-gnueabihf",
+          "fta"
+        );
       }
       break;
     default:

--- a/packages/fta/package.json
+++ b/packages/fta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fta-cli",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "FTA (Fast TypeScript Analyzer) is a super-fast TypeScript static analysis tool written in Rust",
   "repository": "https://github.com/sgb-io/fta.git",
   "author": "sgb-io <sam@sgb.io>",


### PR DESCRIPTION
- Build ubuntu binaries on 20.04 rather than latest, to ensure glibc requirements are met
- Fix `chmod` patch for linux binaries which were missing the actual binary name (!)

Fixes #27 