### PR TITLE
Use the stdio inherit option when executing the tool

### DIFF
--- a/packages/fta/index.js
+++ b/packages/fta/index.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const { execSync } = require("node:child_process");
+const { execSync, spawn } = require("node:child_process");
 const path = require("node:path");
 const fs = require("node:fs");
 
@@ -55,18 +55,20 @@ function runFta(project, options) {
   const binaryPath = getBinaryPath();
   const binaryArgs = options.json ? "--json" : "";
   setUnixPerms(binaryPath);
-  const result = execSync(`${binaryPath} ${project} ${binaryArgs}`);
+  const result = execSync(`${binaryPath} ${project} ${binaryArgs}`, {
+    stdio: "inherit",
+  });
   return result.toString();
 }
 
 // Run the binary directly if executed as a standalone script
 // Arguments are directly forwarded to the binary
 if (require.main === module) {
-  const args = process.argv.slice(2); // Exclude the first two arguments (node binary and script file)
+  const args = process.argv.slice(2); // Exclude the first two arguments (node binary and project path)
   const binaryPath = getBinaryPath();
   const binaryArgs = args.join(" ");
   setUnixPerms(binaryPath);
-  const result = execSync(`${binaryPath} ${binaryArgs}`);
+  const result = execSync(`${binaryPath} ${binaryArgs}`, { stdio: "inherit" });
   console.log(result.toString());
 }
 

--- a/packages/fta/index.js
+++ b/packages/fta/index.js
@@ -55,9 +55,7 @@ function runFta(project, options) {
   const binaryPath = getBinaryPath();
   const binaryArgs = options.json ? "--json" : "";
   setUnixPerms(binaryPath);
-  const result = execSync(`${binaryPath} ${project} ${binaryArgs}`, {
-    stdio: "inherit",
-  });
+  const result = execSync(`${binaryPath} ${project} ${binaryArgs}`);
   return result.toString();
 }
 
@@ -68,8 +66,9 @@ if (require.main === module) {
   const binaryPath = getBinaryPath();
   const binaryArgs = args.join(" ");
   setUnixPerms(binaryPath);
-  const result = execSync(`${binaryPath} ${binaryArgs}`, { stdio: "inherit" });
-  console.log(result.toString());
+
+  // Standard output will be printed due to use of `inherit`, i.e, no need to `console.log` anything
+  execSync(`${binaryPath} ${binaryArgs}`, { stdio: "inherit" });
 }
 
 module.exports.runFta = runFta;


### PR DESCRIPTION
This fixes an issue where parsing very large projects can run into `ENOBUFS` issues. Using `inherit` avoids the buffer limit that is introduced by using `pipe` (the default).

Resolves #48.

There is no test in the project to verify this fix and introducing one seems impractical given the nature of the problem. That said, the fix can be verified using some small node scripts like so:

```javascript
const { execSync } = require("child_process");

try {
  // Run output.js and capture its stdout
  const output = execSync("node output.js", {
    maxBuffer: 50 * 1024,
    stdio: "inherit", // Switch between pipe and inherit to see the ENOBUFS issue
  }); // Intentionally set a low maxBuffer
  console.log(output.toString());
} catch (error) {
  console.error(`Caught an error: ${error.message}`);
}
```

```javascript
// output.js
console.log("A".repeat(2 ** 26)); // Outputs a large 64MB string
```