### PR TITLE
51: Add config path CLI argument

### DIFF
--- a/crates/fta/src/config/tests.rs
+++ b/crates/fta/src/config/tests.rs
@@ -22,10 +22,10 @@ mod tests {
     }
     "#;
 
-        let temp_file = create_temp_file(valid_json);
+        let temp_file: NamedTempFile = create_temp_file(valid_json);
         let path = temp_file.path().to_str().unwrap();
 
-        let config = read_config(path);
+        let config = read_config(path.to_string(), false);
 
         assert_eq!(
             config.extensions,
@@ -71,7 +71,7 @@ mod tests {
         let temp_file = create_temp_file(partial_json);
         let path = temp_file.path().to_str().unwrap();
 
-        let config = read_config(path);
+        let config = read_config(path.to_string(), false);
 
         assert_eq!(
             config.extensions,
@@ -108,7 +108,7 @@ mod tests {
     fn test_read_config_with_nonexistent_file() {
         let nonexistent_path = "nonexistent_file.json";
 
-        let config = read_config(nonexistent_path);
+        let config = read_config(nonexistent_path.to_string(), false);
 
         assert_eq!(
             config.extensions,
@@ -137,5 +137,54 @@ mod tests {
         );
         assert_eq!(config.output_limit, Some(5000));
         assert_eq!(config.score_cap, Some(1000));
+    }
+
+    #[test]
+    fn test_read_config_with_user_specified_file_path() {
+        let valid_json = r#"
+    {
+        "extensions": [".go"],
+        "exclude_filenames": [".tmp.go"],
+        "exclude_directories": ["/test"],
+        "output_limit": 2500,
+        "score_cap": 500
+    }
+    "#;
+
+        let temp_file: NamedTempFile = create_temp_file(valid_json);
+        let path = temp_file.path().to_str().unwrap();
+
+        let config = read_config(path.to_string(), true);
+
+        assert_eq!(
+            config.extensions,
+            Some(vec![
+                ".js".to_string(),
+                ".jsx".to_string(),
+                ".ts".to_string(),
+                ".tsx".to_string(),
+                ".go".to_string()
+            ])
+        );
+        assert_eq!(
+            config.exclude_filenames,
+            Some(vec![
+                ".d.ts".to_string(),
+                ".min.js".to_string(),
+                ".bundle.js".to_string(),
+                ".tmp.go".to_string()
+            ])
+        );
+        assert_eq!(
+            config.exclude_directories,
+            Some(vec![
+                "/dist".to_string(),
+                "/bin".to_string(),
+                "/build".to_string(),
+                "/test".to_string()
+            ])
+        );
+        assert_eq!(config.output_limit, Some(2500));
+        assert_eq!(config.score_cap, Some(500));
     }
 }

--- a/crates/fta/src/config/tests.rs
+++ b/crates/fta/src/config/tests.rs
@@ -23,10 +23,10 @@ mod tests {
     }
     "#;
 
-        let temp_file: NamedTempFile = create_temp_file(valid_json);
+        let temp_file = create_temp_file(valid_json);
         let path = temp_file.path().to_str().unwrap();
 
-        let config = read_config(path.to_string(), false);
+        let config = read_config(path.to_string(), false).unwrap();
 
         assert_eq!(
             config.extensions,
@@ -73,7 +73,7 @@ mod tests {
         let temp_file = create_temp_file(partial_json);
         let path = temp_file.path().to_str().unwrap();
 
-        let config = read_config(path.to_string(), false);
+        let config = read_config(path.to_string(), false).unwrap();
 
         assert_eq!(
             config.extensions,
@@ -110,7 +110,7 @@ mod tests {
     fn test_read_config_with_nonexistent_file() {
         let nonexistent_path = "nonexistent_file.json";
 
-        let config = read_config(nonexistent_path.to_string(), false);
+        let config = read_config(nonexistent_path.to_string(), false).unwrap();
 
         assert_eq!(
             config.extensions,
@@ -153,10 +153,10 @@ mod tests {
     }
     "#;
 
-        let temp_file: NamedTempFile = create_temp_file(valid_json);
+        let temp_file = create_temp_file(valid_json);
         let path = temp_file.path().to_str().unwrap();
 
-        let config = read_config(path.to_string(), true);
+        let config = read_config(path.to_string(), true).unwrap();
 
         assert_eq!(
             config.extensions,
@@ -188,5 +188,12 @@ mod tests {
         );
         assert_eq!(config.output_limit, Some(2500));
         assert_eq!(config.score_cap, Some(500));
+    }
+
+    #[test]
+    fn temp_read_config_with_nonexistent_file_and_user_specified_file_path() {
+        let config = read_config(String::from("nonexistent_file.json"), true);
+
+        assert!(config.is_err(), "Expected error, got {:?}", config);
     }
 }

--- a/crates/fta/src/lib.rs
+++ b/crates/fta/src/lib.rs
@@ -11,23 +11,11 @@ use ignore::WalkBuilder;
 use log::debug;
 use log::warn;
 use std::env;
-use std::fmt;
 use std::fs;
 use structs::{FileData, FtaConfig, HalsteadMetrics};
 use swc_ecma_ast::Module;
 use swc_ecma_parser::error::Error;
 use utils::{check_score_cap_breach, get_assessment, is_valid_file, warn_about_language};
-
-#[derive(Debug, Clone)]
-pub struct FTAError {
-    message: String,
-}
-
-impl fmt::Display for FTAError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.message)
-    }
-}
 
 pub fn analyze_file(module: &Module, line_count: usize) -> (usize, HalsteadMetrics, f64) {
     let cyclo = cyclo::cyclomatic_complexity(module);
@@ -123,7 +111,7 @@ fn do_analysis(
     }
 }
 
-pub fn analyze(repo_path: &String, config: &FtaConfig) -> Result<Vec<FileData>, FTAError> {
+pub fn analyze(repo_path: &String, config: &FtaConfig) -> Vec<FileData> {
     // Initialize the logger
     let mut builder = env_logger::Builder::new();
 
@@ -184,5 +172,5 @@ pub fn analyze(repo_path: &String, config: &FtaConfig) -> Result<Vec<FileData>, 
             }
         });
 
-    return Ok(file_data_list);
+    return file_data_list;
 }

--- a/crates/fta/src/lib.rs
+++ b/crates/fta/src/lib.rs
@@ -106,7 +106,7 @@ fn do_analysis(
     }
 }
 
-pub fn analyze(repo_path: &String) -> Vec<FileData> {
+pub fn analyze(repo_path: &String, config_path: Option<String>) -> Vec<FileData> {
     // Initialize the logger
     let mut builder = env_logger::Builder::new();
 
@@ -118,9 +118,11 @@ pub fn analyze(repo_path: &String) -> Vec<FileData> {
     }
     builder.init();
 
-    // Parse user config
-    let config_path = format!("{}/fta.json", repo_path);
-    let config = read_config(&config_path);
+    let (config_path, path_specified_by_user) = match config_path {
+        Some(config_path_arg) => (config_path_arg, true),
+        None => (format!("{}/fta.json", repo_path), false),
+    };
+    let config = read_config(config_path, path_specified_by_user);
 
     let walk = WalkBuilder::new(repo_path)
         .git_ignore(true)

--- a/crates/fta/src/main.rs
+++ b/crates/fta/src/main.rs
@@ -6,8 +6,8 @@ use std::time::Instant;
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Cli {
-    #[arg(required = true, help = "Path to the project to analyze.")]
-    project: String,
+    #[arg(long, short, help = "Path to config file.")]
+    config_path: Option<String>,
 
     #[arg(
         long,
@@ -21,6 +21,9 @@ struct Cli {
 
     #[arg(long, help = "Output as JSON.", conflicts_with = "format")]
     json: bool,
+
+    #[arg(required = true, help = "Path to the project to analyze.")]
+    project: String,
 }
 
 pub fn main() {
@@ -29,7 +32,7 @@ pub fn main() {
 
     let cli = Cli::parse();
 
-    let mut findings = analyze(&cli.project);
+    let mut findings = analyze(&cli.project, cli.config_path);
 
     findings.sort_unstable_by(|a, b| b.fta_score.partial_cmp(&a.fta_score).unwrap());
 

--- a/crates/fta/src/main.rs
+++ b/crates/fta/src/main.rs
@@ -32,7 +32,13 @@ pub fn main() {
 
     let cli = Cli::parse();
 
-    let mut findings = analyze(&cli.project, cli.config_path);
+    let mut findings = match analyze(&cli.project, cli.config_path) {
+        Ok(findings) => findings,
+        Err(err) => {
+            eprintln!("{}", err);
+            std::process::exit(1);
+        }
+    };
 
     findings.sort_unstable_by(|a, b| b.fta_score.partial_cmp(&a.fta_score).unwrap());
 

--- a/crates/fta/src/main.rs
+++ b/crates/fta/src/main.rs
@@ -46,13 +46,7 @@ pub fn main() {
         }
     };
 
-    let mut findings = match analyze(&cli.project, &config) {
-        Ok(findings) => findings,
-        Err(err) => {
-            eprintln!("{}", err);
-            std::process::exit(1);
-        }
-    };
+    let mut findings = analyze(&cli.project, &config);
 
     findings.sort_unstable_by(|a, b| b.fta_score.partial_cmp(&a.fta_score).unwrap());
 


### PR DESCRIPTION
Adds optional config path CLI argument...

- `read_config` now returns a `Result<FtaConfig, ConfigError>`
- User errors should bubble up to main to be displayed, this is instead of panicking [(as loosely interpreted from the rust book)](https://doc.rust-lang.org/book/ch09-03-to-panic-or-not-to-panic.html)