### PR TITLE
ci: Trigger the release workflow whenever a release was created

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 name: Build Binaries & Release
 
 on:
-  push:
-    tags:
-      - "v*"
+  release:
+    types: [ created ]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
This uses the
[release](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release) workflow event rather than check for specific tags pushed. Unless I misunderstand how you handle your tags, this should be slightly more robust (and also you don't need to care about the tag name).