### PR TITLE
Add exclude_under option to exclude small files by default

### DIFF
--- a/crates/fta/src/config/mod.rs
+++ b/crates/fta/src/config/mod.rs
@@ -1,4 +1,4 @@
-use crate::structs::FtaConfig;
+use crate::structs::{FtaConfigOptional, FtaConfigResolved};
 use std::fmt;
 use std::fs::File;
 use std::io::Read;
@@ -17,28 +17,53 @@ impl fmt::Display for ConfigError {
     }
 }
 
-pub fn get_default_config() -> FtaConfig {
-    let default_config = FtaConfig {
-        extensions: Some(vec![
+impl From<FtaConfigOptional> for FtaConfigResolved {
+    fn from(opt_config: FtaConfigOptional) -> Self {
+        let default_config = get_default_config();
+        FtaConfigResolved {
+            extensions: opt_config.extensions.unwrap_or(default_config.extensions),
+            exclude_filenames: opt_config
+                .exclude_filenames
+                .unwrap_or(default_config.exclude_filenames),
+            exclude_directories: opt_config
+                .exclude_directories
+                .unwrap_or(default_config.exclude_directories),
+            output_limit: opt_config
+                .output_limit
+                .unwrap_or(default_config.output_limit),
+            score_cap: opt_config.score_cap.unwrap_or(default_config.score_cap),
+            include_comments: opt_config
+                .include_comments
+                .unwrap_or(default_config.include_comments),
+            exclude_under: opt_config
+                .exclude_under
+                .unwrap_or(default_config.exclude_under),
+        }
+    }
+}
+
+pub fn get_default_config() -> FtaConfigResolved {
+    let default_config = FtaConfigResolved {
+        extensions: vec![
             ".js".to_string(),
             ".jsx".to_string(),
             ".ts".to_string(),
             ".tsx".to_string(),
-        ]),
-        exclude_filenames: Some(vec![
+        ],
+        exclude_filenames: vec![
             ".d.ts".to_string(),
             ".min.js".to_string(),
             ".bundle.js".to_string(),
-        ]),
-        exclude_directories: Some(vec![
+        ],
+        exclude_directories: vec![
             "/dist".to_string(),
             "/bin".to_string(),
             "/build".to_string(),
-        ]),
-        output_limit: Some(5000),
-        score_cap: Some(1000),
-        include_comments: Some(false),
-        exclude_under: Some(6),
+        ],
+        output_limit: 5000,
+        score_cap: 1000,
+        include_comments: false,
+        exclude_under: 6,
     };
 
     default_config
@@ -47,44 +72,50 @@ pub fn get_default_config() -> FtaConfig {
 pub fn read_config(
     config_path: String,
     path_specified_by_user: bool,
-) -> Result<FtaConfig, ConfigError> {
+) -> Result<FtaConfigResolved, ConfigError> {
     let default_config = get_default_config();
     if Path::new(&config_path).exists() {
         let mut file = File::open(config_path).unwrap();
         let mut content = String::new();
         file.read_to_string(&mut content).unwrap();
-        let provided_config: FtaConfig = serde_json::from_str(&content).unwrap_or_default();
+        let provided_config: FtaConfigOptional = serde_json::from_str(&content).unwrap_or_default();
 
-        return Result::Ok(FtaConfig {
+        // For extensions, filenames and exclude_directories,
+        // user-provided values are added to the defaults.
+        return Result::Ok(FtaConfigResolved {
             extensions: {
-                let mut extensions = default_config.extensions.unwrap();
+                let mut extensions = default_config.extensions;
                 if let Some(mut provided) = provided_config.extensions {
                     extensions.append(&mut provided);
                 }
-                Some(extensions)
+                extensions
             },
             exclude_filenames: {
-                let mut exclude_filenames = default_config.exclude_filenames.unwrap();
+                let mut exclude_filenames = default_config.exclude_filenames;
                 if let Some(mut provided) = provided_config.exclude_filenames {
                     exclude_filenames.append(&mut provided);
                 }
-                Some(exclude_filenames)
+                exclude_filenames
             },
             exclude_directories: {
-                let mut exclude_directories = default_config.exclude_directories.unwrap();
+                let mut exclude_directories = default_config.exclude_directories;
                 if let Some(mut provided) = provided_config.exclude_directories {
                     exclude_directories.append(&mut provided);
                 }
-                Some(exclude_directories)
+                exclude_directories
             },
-            output_limit: provided_config.output_limit.or(default_config.output_limit),
-            score_cap: provided_config.score_cap.or(default_config.score_cap),
+            output_limit: provided_config
+                .output_limit
+                .unwrap_or(default_config.output_limit),
+            score_cap: provided_config
+                .score_cap
+                .unwrap_or(default_config.score_cap),
             exclude_under: provided_config
                 .exclude_under
-                .or(default_config.exclude_under),
+                .unwrap_or(default_config.exclude_under),
             include_comments: provided_config
                 .include_comments
-                .or(default_config.include_comments),
+                .unwrap_or(default_config.include_comments),
         });
     }
 

--- a/crates/fta/src/config/mod.rs
+++ b/crates/fta/src/config/mod.rs
@@ -17,10 +17,7 @@ impl fmt::Display for ConfigError {
     }
 }
 
-pub fn read_config(
-    config_path: String,
-    path_specified_by_user: bool,
-) -> Result<FtaConfig, ConfigError> {
+pub fn get_default_config() -> FtaConfig {
     let default_config = FtaConfig {
         extensions: Some(vec![
             ".js".to_string(),
@@ -44,6 +41,14 @@ pub fn read_config(
         exclude_under: Some(6),
     };
 
+    default_config
+}
+
+pub fn read_config(
+    config_path: String,
+    path_specified_by_user: bool,
+) -> Result<FtaConfig, ConfigError> {
+    let default_config = get_default_config();
     if Path::new(&config_path).exists() {
         let mut file = File::open(config_path).unwrap();
         let mut content = String::new();

--- a/crates/fta/src/config/mod.rs
+++ b/crates/fta/src/config/mod.rs
@@ -41,6 +41,7 @@ pub fn read_config(
         output_limit: Some(5000),
         score_cap: Some(1000),
         include_comments: Some(false),
+        exclude_under: Some(6),
     };
 
     if Path::new(&config_path).exists() {
@@ -73,6 +74,9 @@ pub fn read_config(
             },
             output_limit: provided_config.output_limit.or(default_config.output_limit),
             score_cap: provided_config.score_cap.or(default_config.score_cap),
+            exclude_under: provided_config
+                .exclude_under
+                .or(default_config.exclude_under),
             include_comments: provided_config
                 .include_comments
                 .or(default_config.include_comments),

--- a/crates/fta/src/config/tests.rs
+++ b/crates/fta/src/config/tests.rs
@@ -14,9 +14,10 @@ mod tests {
     fn test_read_config_with_valid_json() {
         let valid_json = r#"
     {
-        "extensions": [".go"],
-        "exclude_filenames": [".tmp.go"],
-        "exclude_directories": ["/test"],
+        "extensions": [".foo.ts"],
+        "exclude_filenames": [".bar.ts"],
+        "exclude_directories": ["/baz"],
+        "exclude_under": 10,
         "output_limit": 2500,
         "score_cap": 500,
         "include_comments": true
@@ -25,85 +26,84 @@ mod tests {
 
         let temp_file = create_temp_file(valid_json);
         let path = temp_file.path().to_str().unwrap();
-
         let config = read_config(path.to_string(), false).unwrap();
 
         assert_eq!(
             config.extensions,
-            Some(vec![
+            vec![
                 ".js".to_string(),
                 ".jsx".to_string(),
                 ".ts".to_string(),
                 ".tsx".to_string(),
-                ".go".to_string()
-            ])
+                ".foo.ts".to_string()
+            ]
         );
         assert_eq!(
             config.exclude_filenames,
-            Some(vec![
+            vec![
                 ".d.ts".to_string(),
                 ".min.js".to_string(),
                 ".bundle.js".to_string(),
-                ".tmp.go".to_string()
-            ])
+                ".bar.ts".to_string()
+            ]
         );
         assert_eq!(
             config.exclude_directories,
-            Some(vec![
+            vec![
                 "/dist".to_string(),
                 "/bin".to_string(),
                 "/build".to_string(),
-                "/test".to_string()
-            ])
+                "/baz".to_string(),
+            ]
         );
-        assert_eq!(config.output_limit, Some(2500));
-        assert_eq!(config.score_cap, Some(500));
-        assert_eq!(config.include_comments, Some(true));
+        assert_eq!(config.output_limit, 2500);
+        assert_eq!(config.score_cap, 500);
+        assert_eq!(config.include_comments, true);
     }
 
     #[test]
     fn test_read_config_with_partial_json() {
         let partial_json = r#"
     {
-        "extensions": [".go"],
-        "exclude_filenames": [".tmp.go"]
+        "extensions": [".foo.ts"],
+        "exclude_filenames": [".bar.ts"]
     }
     "#;
 
         let temp_file = create_temp_file(partial_json);
         let path = temp_file.path().to_str().unwrap();
-
         let config = read_config(path.to_string(), false).unwrap();
 
         assert_eq!(
             config.extensions,
-            Some(vec![
+            vec![
                 ".js".to_string(),
                 ".jsx".to_string(),
                 ".ts".to_string(),
                 ".tsx".to_string(),
-                ".go".to_string()
-            ])
+                ".foo.ts".to_string()
+            ]
         );
         assert_eq!(
             config.exclude_filenames,
-            Some(vec![
+            vec![
                 ".d.ts".to_string(),
                 ".min.js".to_string(),
                 ".bundle.js".to_string(),
-                ".tmp.go".to_string()
-            ])
+                ".bar.ts".to_string()
+            ]
         );
         assert_eq!(
             config.exclude_directories,
-            Some(vec![
+            vec![
                 "/dist".to_string(),
                 "/bin".to_string(),
-                "/build".to_string()
-            ])
+                "/build".to_string(),
+            ]
         );
-        assert_eq!(config.output_limit, Some(5000));
-        assert_eq!(config.score_cap, Some(1000));
+        assert_eq!(config.output_limit, 5000);
+        assert_eq!(config.score_cap, 1000);
+        assert_eq!(config.include_comments, false);
     }
 
     #[test]
@@ -114,40 +114,41 @@ mod tests {
 
         assert_eq!(
             config.extensions,
-            Some(vec![
+            vec![
                 ".js".to_string(),
                 ".jsx".to_string(),
                 ".ts".to_string(),
-                ".tsx".to_string()
-            ])
+                ".tsx".to_string(),
+            ]
         );
         assert_eq!(
             config.exclude_filenames,
-            Some(vec![
+            vec![
                 ".d.ts".to_string(),
                 ".min.js".to_string(),
-                ".bundle.js".to_string()
-            ])
+                ".bundle.js".to_string(),
+            ]
         );
         assert_eq!(
             config.exclude_directories,
-            Some(vec![
+            vec![
                 "/dist".to_string(),
                 "/bin".to_string(),
-                "/build".to_string()
-            ])
+                "/build".to_string(),
+            ]
         );
-        assert_eq!(config.output_limit, Some(5000));
-        assert_eq!(config.score_cap, Some(1000));
+        assert_eq!(config.output_limit, 5000);
+        assert_eq!(config.score_cap, 1000);
+        assert_eq!(config.include_comments, false);
     }
 
     #[test]
     fn test_read_config_with_user_specified_file_path() {
         let valid_json = r#"
     {
-        "extensions": [".go"],
-        "exclude_filenames": [".tmp.go"],
-        "exclude_directories": ["/test"],
+        "extensions": [".foo.ts"],
+        "exclude_filenames": [".bar.ts"],
+        "exclude_directories": ["/baz"],
         "output_limit": 2500,
         "score_cap": 500
     }
@@ -160,34 +161,35 @@ mod tests {
 
         assert_eq!(
             config.extensions,
-            Some(vec![
+            vec![
                 ".js".to_string(),
                 ".jsx".to_string(),
                 ".ts".to_string(),
                 ".tsx".to_string(),
-                ".go".to_string()
-            ])
+                ".foo.ts".to_string(),
+            ]
         );
         assert_eq!(
             config.exclude_filenames,
-            Some(vec![
+            vec![
                 ".d.ts".to_string(),
                 ".min.js".to_string(),
                 ".bundle.js".to_string(),
-                ".tmp.go".to_string()
-            ])
+                ".bar.ts".to_string(),
+            ]
         );
         assert_eq!(
             config.exclude_directories,
-            Some(vec![
+            vec![
                 "/dist".to_string(),
                 "/bin".to_string(),
                 "/build".to_string(),
-                "/test".to_string()
-            ])
+                "/baz".to_string(),
+            ]
         );
-        assert_eq!(config.output_limit, Some(2500));
-        assert_eq!(config.score_cap, Some(500));
+        assert_eq!(config.output_limit, 2500);
+        assert_eq!(config.score_cap, 500);
+        assert_eq!(config.include_comments, false);
     }
 
     #[test]

--- a/crates/fta/src/lib.rs
+++ b/crates/fta/src/lib.rs
@@ -167,8 +167,11 @@ pub fn analyze(repo_path: &String, config: &FtaConfig) -> Vec<FileData> {
                 return;
             }
 
-            if let Ok(data) = file_data_result {
-                file_data_list.push(data);
+            // Only inclued files that are equal to or greater than the `exclude_under` option
+            let exclude_under_actual = config.exclude_under.unwrap_or(6);
+            match file_data_result {
+                Ok(data) if data.line_count > exclude_under_actual => file_data_list.push(data),
+                _ => {}
             }
         });
 

--- a/crates/fta/src/main.rs
+++ b/crates/fta/src/main.rs
@@ -60,7 +60,7 @@ pub fn main() {
             cli.format
         },
         &elapsed,
-        config.output_limit.unwrap_or_default(),
+        config.output_limit,
     );
 
     println!("{}", output);

--- a/crates/fta/src/structs/mod.rs
+++ b/crates/fta/src/structs/mod.rs
@@ -8,6 +8,7 @@ pub struct FtaConfig {
     pub output_limit: Option<usize>,
     pub score_cap: Option<usize>,
     pub include_comments: Option<bool>,
+    pub exclude_under: Option<usize>,
 }
 
 #[derive(Debug, Serialize, PartialEq)]

--- a/crates/fta/src/structs/mod.rs
+++ b/crates/fta/src/structs/mod.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Default)]
-pub struct FtaConfig {
+pub struct FtaConfigOptional {
     pub extensions: Option<Vec<String>>,
     pub exclude_filenames: Option<Vec<String>>,
     pub exclude_directories: Option<Vec<String>>,
@@ -9,6 +9,17 @@ pub struct FtaConfig {
     pub score_cap: Option<usize>,
     pub include_comments: Option<bool>,
     pub exclude_under: Option<usize>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct FtaConfigResolved {
+    pub extensions: Vec<String>,
+    pub exclude_filenames: Vec<String>,
+    pub exclude_directories: Vec<String>,
+    pub output_limit: usize,
+    pub score_cap: usize,
+    pub include_comments: bool,
+    pub exclude_under: usize,
 }
 
 #[derive(Debug, Serialize, PartialEq)]

--- a/crates/fta/src/walk/mod.rs
+++ b/crates/fta/src/walk/mod.rs
@@ -1,0 +1,31 @@
+use crate::structs::{FileData, FtaConfig};
+use ignore::DirEntry;
+
+pub fn walk_and_analyze_files<I, P, V>(
+    entries: I,
+    repo_path: &String,
+    config: &FtaConfig,
+    process_entry: P,
+    is_valid: V,
+) -> Vec<FileData>
+where
+    I: Iterator<Item = Result<DirEntry, ignore::Error>>,
+    P: Fn(DirEntry, &String, &FtaConfig) -> Option<Vec<FileData>>,
+    V: Fn(&String, &DirEntry, &FtaConfig) -> bool,
+{
+    let mut file_data_list: Vec<FileData> = Vec::new();
+
+    entries
+        // 1. Were we able to successfully read the DirEntry & is it a file?
+        .filter(|entry| entry.is_ok())
+        .map(|entry| entry.unwrap())
+        .filter(|entry| entry.file_type().unwrap().is_file())
+        // 2. Is the file considered valid according to our basic requirements plus user configuration?
+        .filter(|entry| is_valid(repo_path, &entry, config))
+        // 3. Analyze each file
+        .filter_map(|entry| process_entry(entry, repo_path, config))
+        // 4. Return a list of analyzed files
+        .for_each(|data_vec| file_data_list.extend(data_vec));
+
+    file_data_list
+}

--- a/crates/fta/src/walk/mod.rs
+++ b/crates/fta/src/walk/mod.rs
@@ -1,17 +1,17 @@
-use crate::structs::{FileData, FtaConfig};
+use crate::structs::{FileData, FtaConfigResolved};
 use ignore::DirEntry;
 
 pub fn walk_and_analyze_files<I, P, V>(
     entries: I,
     repo_path: &String,
-    config: &FtaConfig,
+    config: &FtaConfigResolved,
     process_entry: P,
     is_valid: V,
 ) -> Vec<FileData>
 where
     I: Iterator<Item = Result<DirEntry, ignore::Error>>,
-    P: Fn(DirEntry, &String, &FtaConfig) -> Option<Vec<FileData>>,
-    V: Fn(&String, &DirEntry, &FtaConfig) -> bool,
+    P: Fn(DirEntry, &String, &FtaConfigResolved) -> Option<Vec<FileData>>,
+    V: Fn(&String, &DirEntry, &FtaConfigResolved) -> bool,
 {
     let mut file_data_list: Vec<FileData> = Vec::new();
 


### PR DESCRIPTION
1. Adds a new `exclude_under` option which will exclude files with _n_ comments. The default value is `6`. The `include_comments` option is taken into account with this option.
2. Refactoring: moved the main filewalking step into a new `walk` module.
3. Refactoring: split the `FtaConfig` into two parts: `FtaConfigOptional` and `FtaConfigResolved`. Previously, the everything-is-an-option was used throughout. In reality we actually guarantee the values after `config::read_config` is called. By introducing `FtaConfigResolved`, we have been able to simplify downstream code.
4. Refactored the config tests to use more normal values