### PR TITLE
Expose number and boolean config options as cli options

### DIFF
--- a/crates/fta/src/main.rs
+++ b/crates/fta/src/main.rs
@@ -7,7 +7,10 @@ use std::time::Instant;
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Cli {
-    #[arg(long, short, help = "Path to config file.")]
+    #[arg(required = true, help = "Path to the project to analyze")]
+    project: String,
+
+    #[arg(long, short, help = "Path to config file")]
     config_path: Option<String>,
 
     #[arg(
@@ -15,7 +18,7 @@ struct Cli {
         short,
         default_value = "table",
         value_parser(["table", "csv", "json"]),
-        help = "Output format.",
+        help = "Output format (default: table)",
         conflicts_with = "json"
     )]
     format: String,
@@ -23,8 +26,33 @@ struct Cli {
     #[arg(long, help = "Output as JSON.", conflicts_with = "format")]
     json: bool,
 
-    #[arg(required = true, help = "Path to the project to analyze.")]
-    project: String,
+    #[arg(
+        long,
+        short,
+        help = "Maximum number of files to include in the table output (only applies when using table output) (default: 5000)"
+    )]
+    output_limit: Option<usize>,
+
+    #[arg(
+        long,
+        short,
+        help = "Maximum FTA score which will cause FTA to throw (default: 1000)"
+    )]
+    score_cap: Option<usize>,
+
+    #[arg(
+        long,
+        short,
+        help = "Whether to include code comments when analysing (default: false)"
+    )]
+    include_comments: Option<bool>,
+
+    #[arg(
+        long,
+        short,
+        help = "Minimum number of lines of code for files to be included in output (default: 6)"
+    )]
+    exclude_under: Option<usize>,
 }
 
 pub fn main() {
@@ -33,12 +61,14 @@ pub fn main() {
 
     let cli = Cli::parse();
 
+    // Resolve the fta.json path, which can optionally be used-supplied
     let (config_path, path_specified_by_user) = match cli.config_path {
         Some(config_path_arg) => (config_path_arg, true),
         None => (format!("{}/fta.json", cli.project), false),
     };
 
-    let config = match read_config(config_path, path_specified_by_user) {
+    // Resolve the input config. Optionally adds fta.json values to the default config.
+    let mut config = match read_config(config_path, path_specified_by_user) {
         Ok(config) => config,
         Err(err) => {
             eprintln!("{}", err);
@@ -46,12 +76,30 @@ pub fn main() {
         }
     };
 
+    // Override config with CLI args where allowed + values are provided
+    if let Some(value) = cli.output_limit {
+        config.output_limit = value;
+    }
+    if let Some(value) = cli.score_cap {
+        config.score_cap = value;
+    }
+    if let Some(value) = cli.include_comments {
+        config.include_comments = value;
+    }
+    if let Some(value) = cli.exclude_under {
+        config.exclude_under = value;
+    }
+
+    // Execute the analysis
     let mut findings = analyze(&cli.project, &config);
 
+    // Sort the result for display
     findings.sort_unstable_by(|a, b| b.fta_score.partial_cmp(&a.fta_score).unwrap());
 
+    // Execution finished, capture elapsed time
     let elapsed = start.elapsed().as_secs_f64();
 
+    // Format and display the results
     let output = generate_output(
         &findings,
         if cli.json {


### PR DESCRIPTION
Exposes several of the config options as CLI arguments. If the user supplies these as CLI arguments, the CLI argument value wins.

The following become exposed:

- `output_limit`
- `score_cap`
- `include_comments`
- `exclude_under`

Note, the following string array options are not included in this:

- `extensions`
- `exclude_filenames`
- `exclude_directories`

This is because accepting array string values as CLI input is much more complex vs plain number or boolean values. This could potentially be added later if there is demand for it.

Partially resolves #50 

Updated help text:

```
Fast TypeScript Analyzer

Usage: fta.exe [OPTIONS] <PROJECT>

Arguments:
  <PROJECT>  Path to the project to analyze

Options:
  -c, --config-path <CONFIG_PATH>
          Path to config file
  -f, --format <FORMAT>
          Output format (default: table) [default: table] [possible values: table, csv, json]
      --json
          Output as JSON.
  -o, --output-limit <OUTPUT_LIMIT>
          Maximum number of files to include in the table output (only applies when using table output) (default: 5000)
  -s, --score-cap <SCORE_CAP>
          Maximum FTA score which will cause FTA to throw (default: 1000)
  -i, --include-comments <INCLUDE_COMMENTS>
          Whether to include code comments when analysing (default: false) [possible values: true, false]
  -e, --exclude-under <EXCLUDE_UNDER>
          Minimum number of lines of code for files to be included in output (default: 6)
  -h, --help
          Print help
  -V, --version
          Print version
```