### PR TITLE
Fix wasm build by introducing a feature flag to the main crate

### DIFF
--- a/crates/fta-wasm/Cargo.toml
+++ b/crates/fta-wasm/Cargo.toml
@@ -12,6 +12,6 @@ repository = "https://github.com/sgb-io/fta"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-fta = { path = "../fta" }
+fta = { path = "../fta", default-features = false }
 serde_json = "1.0.96"
 wasm-bindgen = "0.2.85"

--- a/crates/fta/Cargo.toml
+++ b/crates/fta/Cargo.toml
@@ -11,7 +11,7 @@ readme = "../../README.md"
 
 [dependencies]
 clap = { version = "4.2.7", features = ["derive"] }
-comfy-table = "7.0.0"
+comfy-table = { version = "7.0.0", optional = true }
 env_logger = "0.9"
 globset = "0.4"
 ignore = "0.4"
@@ -23,3 +23,7 @@ swc_ecma_ast = "0.106.0"
 swc_ecma_parser = "0.136.0"
 swc_ecma_visit = "0.92.0"
 tempfile = "3.2.0"
+
+[features]
+default = ["use_output"]
+use_output = ["comfy-table"]

--- a/crates/fta/src/lib.rs
+++ b/crates/fta/src/lib.rs
@@ -1,11 +1,13 @@
 pub mod config;
 mod cyclo;
 mod halstead;
-pub mod output;
 pub mod parse;
 mod structs;
 mod utils;
 mod walk;
+
+#[cfg(feature = "use_output")]
+pub mod output;
 
 use ignore::DirEntry;
 use ignore::WalkBuilder;

--- a/crates/fta/src/main.rs
+++ b/crates/fta/src/main.rs
@@ -1,8 +1,10 @@
 use clap::Parser;
 use fta::analyze;
 use fta::config::read_config;
-use fta::output::generate_output;
 use std::time::Instant;
+
+#[cfg(feature = "use_output")]
+use fta::output::generate_output;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -98,18 +100,20 @@ pub fn main() {
 
     // Execution finished, capture elapsed time
     let elapsed = start.elapsed().as_secs_f64();
+    #[cfg(feature = "use_output")]
+    {
+        // Format and display the results
+        let output = generate_output(
+            &findings,
+            if cli.json {
+                "json".to_string()
+            } else {
+                cli.format
+            },
+            &elapsed,
+            config.output_limit,
+        );
 
-    // Format and display the results
-    let output = generate_output(
-        &findings,
-        if cli.json {
-            "json".to_string()
-        } else {
-            cli.format
-        },
-        &elapsed,
-        config.output_limit,
-    );
-
-    println!("{}", output);
+        println!("{}", output);
+    }
 }

--- a/crates/fta/src/output/mod.rs
+++ b/crates/fta/src/output/mod.rs
@@ -1,6 +1,7 @@
 use crate::structs::FileData;
-use comfy_table::presets::UTF8_FULL;
-use comfy_table::Table;
+
+#[cfg(feature = "use_output")]
+use comfy_table::{presets::UTF8_FULL, Table};
 
 mod tests;
 

--- a/crates/fta/src/output/mod.rs
+++ b/crates/fta/src/output/mod.rs
@@ -1,6 +1,4 @@
 use crate::structs::FileData;
-
-#[cfg(feature = "use_output")]
 use comfy_table::{presets::UTF8_FULL, Table};
 
 mod tests;


### PR DESCRIPTION
Adds a feature flag to the `fta` crate which causes the `output` module and particularly `comfy-table` to be excluded from the wasm build. `comfy-table` isn't needed for the wasm build, plus breaks it, since it relies on `sys` calls that are unavailable in the wasm environment.

Resolves #68 