### PR TITLE
ci: Group dependabot dependencies updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
IMO most project do not really benefit from having x10 granular PRs for automated dependencies updates. With this change, dependabot will submit one grouped PR every week. If there is a problematic update, then we can create a dedicate PR to update the offending dependency (as it likely requires manual action anyway) and the rest can still be udpated automatically in one go.