### PR TITLE
Upgrade GitHub action versions to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
           tar czvf aarch64-apple-darwin.tar.gz -C target/aarch64-apple-darwin/release fta
 
       - name: Upload binaries as artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: macos-binaries
           path: |
@@ -110,7 +110,7 @@ jobs:
           Compress-Archive -Path target/aarch64-pc-windows-msvc/release/fta.exe -DestinationPath aarch64-pc-windows-msvc.zip
 
       - name: Upload binaries as artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: windows-binaries
           path: |
@@ -179,7 +179,7 @@ jobs:
           done
 
       - name: Upload binaries as artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: linux-binaries
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,10 +10,10 @@ jobs:
   upload_assets_macos:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Cache Cargo packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         continue-on-error: false
         with:
           path: |
@@ -67,10 +67,10 @@ jobs:
   upload_assets_windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Cache Cargo packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         continue-on-error: false
         with:
           path: |
@@ -119,10 +119,10 @@ jobs:
   upload_assets_linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Cache Cargo packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         continue-on-error: false
         with:
           path: |

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v3

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -10,24 +10,24 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Download macOS artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: macos-binaries
           path: artifact/
 
       - name: Download linux artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: linux-binaries
           path: artifact/
 
       - name: Download windows artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: windows-binaries
           path: artifact/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
   create_github_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Get version
         id: get_version
         run: |
@@ -41,7 +41,7 @@ jobs:
     needs: [create_github_release, build_binaries]
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Download macOS artifact
         uses: actions/download-artifact@v2
@@ -79,7 +79,7 @@ jobs:
     needs: [create_github_release, build_binaries]
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Download windows artifact
         uses: actions/download-artifact@v2
@@ -117,7 +117,7 @@ jobs:
     needs: [create_github_release, build_binaries]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Download linux artifact
         uses: actions/download-artifact@v2
@@ -158,7 +158,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [upload_assets_macos, upload_assets_windows, upload_assets_linux]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Update packages
         run: sudo apt-get update
       - name: Install Rust
@@ -180,13 +180,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '16.x'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: "16.x"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Download macOS artifacts
         uses: actions/download-artifact@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Download macOS artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: macos-binaries
 
@@ -69,7 +69,7 @@ jobs:
           asset_content_type: application/gzip
 
       - name: Upload binaries as artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: macos-binaries
           path: |
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Download windows artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: windows-binaries
 
@@ -107,7 +107,7 @@ jobs:
           asset_content_type: application/zip
 
       - name: Upload binaries as artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: windows-binaries
           path: |
@@ -120,7 +120,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Download linux artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: linux-binaries
 
@@ -189,19 +189,19 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Download macOS artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: macos-binaries
           path: artifact/
 
       - name: Download linux artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: linux-binaries
           path: artifact/
 
       - name: Download windows artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: windows-binaries
           path: artifact/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
   test_rust_crate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1
@@ -50,8 +50,8 @@ jobs:
 
   build_binaries:
     uses: ./.github/workflows/build.yml
-  
-  test_built_binaries: 
+
+  test_built_binaries:
     needs: build_binaries
     runs-on: ${{ matrix.os }}
     strategy:
@@ -65,7 +65,7 @@ jobs:
           - os: ubuntu-latest
             artifact: linux-binaries
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Download artifact
         uses: actions/download-artifact@v2
@@ -78,10 +78,10 @@ jobs:
         shell: pwsh
         run: |
           $sourcePath = "artifact"
-          
+
           # Get all .zip files from the sourcePath directory
           $files = Get-ChildItem -Path $sourcePath -Recurse -Include "*.zip"
-          
+
           # Loop through each .zip file
           foreach ($file in $files) {
             # Extract the file to the current directory

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Download artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.artifact }}
           path: artifact/


### PR DESCRIPTION
For `actions/upload-artifact` and `actions/download-artifact` there were mutability changes in v4 (but v3 was just a Node.js upgrade). Luckily, the breaking changes were not relevant to our usage.

For all the other actions, it's just a Node.js major upgrade (v20) which should be compatible.

Resolves #163, with the possible exception of the release action