### PR TITLE
Upgrade release actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,8 +54,8 @@ jobs:
 
       - name: Create tarballs and move binaries
         run: |
-          tar czvf x86_64-apple-darwin.tar.gz -C target/x86_64-apple-darwin/release fta
-          tar czvf aarch64-apple-darwin.tar.gz -C target/aarch64-apple-darwin/release fta
+          tar czvf fta-x86_64-apple-darwin.tar.gz -C target/x86_64-apple-darwin/release fta
+          tar czvf fta-aarch64-apple-darwin.tar.gz -C target/aarch64-apple-darwin/release fta
 
       - name: Upload binaries as artifacts
         uses: actions/upload-artifact@v4
@@ -106,8 +106,8 @@ jobs:
       - name: Create zipfiles and move binaries
         shell: pwsh
         run: |
-          Compress-Archive -Path target/x86_64-pc-windows-msvc/release/fta.exe -DestinationPath x86_64-pc-windows-msvc.zip
-          Compress-Archive -Path target/aarch64-pc-windows-msvc/release/fta.exe -DestinationPath aarch64-pc-windows-msvc.zip
+          Compress-Archive -Path target/x86_64-pc-windows-msvc/release/fta.exe -DestinationPath fta-x86_64-pc-windows-msvc.zip
+          Compress-Archive -Path target/aarch64-pc-windows-msvc/release/fta.exe -DestinationPath fta-aarch64-pc-windows-msvc.zip
 
       - name: Upload binaries as artifacts
         uses: actions/upload-artifact@v4
@@ -175,7 +175,7 @@ jobs:
             echo "Building for $TARGET"
             cargo build --release --target="$TARGET"
             chmod +x target/${TARGET}/release/fta
-            tar czf "${TARGET}.tar.gz" -C "./target/${TARGET}/release/" fta
+            tar czf "fta-${TARGET}.tar.gz" -C "./target/${TARGET}/release/" fta
           done
 
       - name: Upload binaries as artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,12 +22,12 @@ jobs:
           echo "FTA_VERSION=$VERSION" >> $GITHUB_OUTPUT
       - name: Create GitHub release
         id: create_release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          release_name: v${{ steps.get_version.outputs.FTA_VERSION }}
+          name: v${{ steps.get_version.outputs.FTA_VERSION }}
           draft: true
           prerelease: false
     outputs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,12 +14,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - name: Get version
         id: get_version
         run: |
           VERSION=$(grep '^version =' crates/fta/Cargo.toml | sed 's/^version = "\(.*\)"/\1/')
           echo "Version: $VERSION"
           echo "FTA_VERSION=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Build binaries
+        uses: ./.github/workflows/build.yml
+
       - name: Create GitHub release
         id: create_release
         uses: softprops/action-gh-release@v2
@@ -30,18 +35,6 @@ jobs:
           name: v${{ steps.get_version.outputs.FTA_VERSION }}
           draft: true
           prerelease: false
-    outputs:
-      version_name: ${{ steps.get_version.outputs.FTA_VERSION }}
-      upload_url: ${{ steps.create_release.outputs.upload_url }}
-
-  build_binaries:
-    uses: ./.github/workflows/build.yml
-
-  upload_all_assets:
-    needs: [create_github_release, build_binaries]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
 
       - name: Download macOS artifacts
         uses: actions/download-artifact@v4
@@ -62,13 +55,13 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            fta-${{ needs.create_github_release.outputs.version_name }}-x86_64-apple-darwin.tar.gz
-            fta-${{ needs.create_github_release.outputs.version_name }}-aarch64-apple-darwin.tar.gz
-            fta-${{ needs.create_github_release.outputs.version_name }}-x86_64-pc-windows-msvc.zip
-            fta-${{ needs.create_github_release.outputs.version_name }}-aarch64-pc-windows-msvc.zip
-            fta-${{ needs.create_github_release.outputs.version_name }}-aarch64-unknown-linux-musl.tar.gz
-            fta-${{ needs.create_github_release.outputs.version_name }}-x86_64-unknown-linux-musl.tar.gz
-            fta-${{ needs.create_github_release.outputs.version_name }}-arm-unknown-linux-musleabi.tar.gz
+            fta-x86_64-apple-darwin.tar.gz
+            fta-aarch64-apple-darwin.tar.gz
+            fta-x86_64-pc-windows-msvc.zip
+            fta-aarch64-pc-windows-msvc.zip
+            fta-aarch64-unknown-linux-musl.tar.gz
+            fta-x86_64-unknown-linux-musl.tar.gz
+            fta-arm-unknown-linux-musleabi.tar.gz
 
   publish_rust_crate:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,122 +37,38 @@ jobs:
   build_binaries:
     uses: ./.github/workflows/build.yml
 
-  upload_assets_macos:
-    needs: [create_github_release, build_binaries]
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Download macOS artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: macos-binaries
-
-      - name: Upload macOS x86 tarball
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_github_release.outputs.upload_url }}
-          asset_path: ./x86_64-apple-darwin.tar.gz
-          asset_name: fta-${{ needs.create_github_release.outputs.version_name }}-x86_64-apple-darwin.tar.gz
-          asset_content_type: application/gzip
-
-      - name: Upload macOS silicon tarball
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_github_release.outputs.upload_url }}
-          asset_path: ./aarch64-apple-darwin.tar.gz
-          asset_name: fta-${{ needs.create_github_release.outputs.version_name }}-aarch64-apple-darwin.tar.gz
-          asset_content_type: application/gzip
-
-      - name: Upload binaries as artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: macos-binaries
-          path: |
-            *.tar.gz
-
-  upload_assets_windows:
-    needs: [create_github_release, build_binaries]
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Download windows artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: windows-binaries
-
-      - name: Upload Windows x86 zipfile
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_github_release.outputs.upload_url }}
-          asset_path: ./x86_64-pc-windows-msvc.zip
-          asset_name: fta-${{ needs.create_github_release.outputs.version_name }}-x86_64-pc-windows-msvc.zip
-          asset_content_type: application/zip
-
-      - name: Upload Windows ARM64 zipfile
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_github_release.outputs.upload_url }}
-          asset_path: ./aarch64-pc-windows-msvc.zip
-          asset_name: fta-${{ needs.create_github_release.outputs.version_name }}-aarch64-pc-windows-msvc.zip
-          asset_content_type: application/zip
-
-      - name: Upload binaries as artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: windows-binaries
-          path: |
-            *.zip
-
-  upload_assets_linux:
+  upload_all_assets:
     needs: [create_github_release, build_binaries]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download linux artifact
+      - name: Download macOS artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: macos-binaries
+
+      - name: Download windows artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-binaries
+
+      - name: Download linux artifacts
         uses: actions/download-artifact@v4
         with:
           name: linux-binaries
 
-      - name: Upload aarch64-unknown-linux-musl tarball
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload all assets
+        uses: softprops/action-gh-release@v2
         with:
-          upload_url: ${{ needs.create_github_release.outputs.upload_url }}
-          asset_path: ./aarch64-unknown-linux-musl.tar.gz
-          asset_name: fta-${{ needs.create_github_release.outputs.version_name }}-aarch64-unknown-linux-musl.tar.gz
-          asset_content_type: application/gzip
-
-      - name: Upload x86_64-unknown-linux-musl tarball
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_github_release.outputs.upload_url }}
-          asset_path: ./x86_64-unknown-linux-musl.tar.gz
-          asset_name: fta-${{ needs.create_github_release.outputs.version_name }}-x86_64-unknown-linux-musl.tar.gz
-          asset_content_type: application/gzip
-
-      - name: Upload arm-unknown-linux-musleabi tarball
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_github_release.outputs.upload_url }}
-          asset_path: ./arm-unknown-linux-musleabi.tar.gz
-          asset_name: fta-${{ needs.create_github_release.outputs.version_name }}-arm-unknown-linux-musleabi.tar.gz
-          asset_content_type: application/gzip
+          files: |
+            fta-${{ needs.create_github_release.outputs.version_name }}-x86_64-apple-darwin.tar.gz
+            fta-${{ needs.create_github_release.outputs.version_name }}-aarch64-apple-darwin.tar.gz
+            fta-${{ needs.create_github_release.outputs.version_name }}-x86_64-pc-windows-msvc.zip
+            fta-${{ needs.create_github_release.outputs.version_name }}-aarch64-pc-windows-msvc.zip
+            fta-${{ needs.create_github_release.outputs.version_name }}-aarch64-unknown-linux-musl.tar.gz
+            fta-${{ needs.create_github_release.outputs.version_name }}-x86_64-unknown-linux-musl.tar.gz
+            fta-${{ needs.create_github_release.outputs.version_name }}-arm-unknown-linux-musleabi.tar.gz
 
   publish_rust_crate:
     runs-on: ubuntu-latest
@@ -185,7 +101,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v4
         with:
-          node-version: "16.x"
+          node-version: "20.x"
           registry-url: "https://registry.npmjs.org"
 
       - name: Download macOS artifacts
@@ -206,7 +122,7 @@ jobs:
           name: windows-binaries
           path: artifact/
 
-      - name: Extract nix artifacts
+      - name: Extract .tar.gz artifacts
         run: |
           for file in artifact/*.tar.gz; do
             base=$(basename -- "$file")
@@ -215,7 +131,7 @@ jobs:
             tar -xzf "$file" -C packages/fta/binaries/"$dirname"
           done
 
-      - name: Extract artifacts
+      - name: Extract .zip artifacts
         run: |
           for file in artifact/*.zip; do
             dir=$(basename "$file" .zip)

--- a/packages/fta/index.js
+++ b/packages/fta/index.js
@@ -13,23 +13,43 @@ function getBinaryPath() {
   switch (platform) {
     case "win32":
       if (architecture === "x64") {
-        return path.join(targetDirectory, "x86_64-pc-windows-msvc", "fta.exe");
+        return path.join(
+          targetDirectory,
+          "fta-x86_64-pc-windows-msvc",
+          "fta.exe"
+        );
       } else if (architecture === "arm64") {
-        return path.join(targetDirectory, "aarch64-pc-windows-msvc", "fta.exe");
+        return path.join(
+          targetDirectory,
+          "fta-aarch64-pc-windows-msvc",
+          "fta.exe"
+        );
       }
     case "darwin":
       if (architecture === "x64") {
-        return path.join(targetDirectory, "x86_64-apple-darwin", "fta");
+        return path.join(targetDirectory, "fta-x86_64-apple-darwin", "fta");
       } else if (architecture === "arm64") {
-        return path.join(targetDirectory, "aarch64-apple-darwin", "fta");
+        return path.join(targetDirectory, "fta-aarch64-apple-darwin", "fta");
       }
     case "linux":
       if (architecture === "x64") {
-        return path.join(targetDirectory, "x86_64-unknown-linux-musl", "fta");
+        return path.join(
+          targetDirectory,
+          "fta-x86_64-unknown-linux-musl",
+          "fta"
+        );
       } else if (architecture === "arm64") {
-        return path.join(targetDirectory, "aarch64-unknown-linux-musl", "fta");
+        return path.join(
+          targetDirectory,
+          "fta-aarch64-unknown-linux-musl",
+          "fta"
+        );
       } else if (architecture === "arm") {
-        return path.join(targetDirectory, "arm-unknown-linux-musleabi", "fta");
+        return path.join(
+          targetDirectory,
+          "fta-arm-unknown-linux-musleabi",
+          "fta"
+        );
       }
       break;
     default:

--- a/packages/fta/targets.js
+++ b/packages/fta/targets.js
@@ -1,14 +1,17 @@
 // Windows
-const exeTargets = ["aarch64-pc-windows-msvc", "x86_64-pc-windows-msvc"];
+const exeTargets = [
+  "fta-aarch64-pc-windows-msvc",
+  "fta-x86_64-pc-windows-msvc",
+];
 
 const plainTargets = [
   // macOS
-  "x86_64-apple-darwin",
-  "aarch64-apple-darwin",
+  "fta-x86_64-apple-darwin",
+  "fta-aarch64-apple-darwin",
   // Linux
-  "x86_64-unknown-linux-musl",
-  "aarch64-unknown-linux-musl",
-  "arm-unknown-linux-musleabi",
+  "fta-x86_64-unknown-linux-musl",
+  "fta-aarch64-unknown-linux-musl",
+  "fta-arm-unknown-linux-musleabi",
 ];
 
 module.exports.exeTargets = exeTargets;


### PR DESCRIPTION
Ditches usage of the deprecated `actions/upload-release-asset@v1` and `actions/upload-release-asset@v1` actions in favour of `softprops/action-gh-release@v2`, in order to ensure the project can still release.

The new action also appears to simplify things, however, I don't know if there any way to test that everything works without attempting a real release.

Note: the new action doesn't appear to support renaming assets when uploading to a GitHub release. Instead, we know apply the `fta-` prefix when building the assets.

Relates to #163 