### PR TITLE
Enable decorators parsing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,10 +159,10 @@ jobs:
 
       - name: Install MUSL toolchain for AArch64
         run: |
-          curl -L --retry 3 --retry-delay 5 --fail -o aarch64-linux-musl-cross.tgz \
-            https://musl.cc/aarch64-linux-musl-cross.tgz
-          tar -xf aarch64-linux-musl-cross.tgz
-          echo "$(pwd)/aarch64-linux-musl-cross/bin" >> $GITHUB_PATH
+          curl -L --retry 3 --retry-delay 5 --fail -o aarch64-linux-musl.tar.xz \
+            https://github.com/cross-tools/musl-cross/releases/download/20250520/aarch64-unknown-linux-musl.tar.xz
+          tar -xf aarch64-linux-musl.tar.xz
+          echo "$(pwd)/aarch64-unknown-linux-musl/bin" >> $GITHUB_PATH
 
       - name: Build and tarball
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,10 +159,11 @@ jobs:
 
       - name: Install MUSL toolchain for AArch64
         run: |
-          curl -L --retry 3 --retry-delay 5 --fail -o aarch64-linux-musl.tar.xz \
-            https://github.com/cross-tools/musl-cross/releases/download/20250520/aarch64-unknown-linux-musl.tar.xz
-          tar -xf aarch64-linux-musl.tar.xz
-          echo "$(pwd)/aarch64-unknown-linux-musl/bin" >> $GITHUB_PATH
+          curl -L --retry 3 --retry-delay 5 --fail \
+            -o aarch64-linux-musl-cross.tgz \
+            https://github.com/sgb-io/fta-dependencies/releases/download/v0.0.01/aarch64-linux-musl-cross.tgz
+          tar -xzf aarch64-linux-musl-cross.tgz
+          echo "$(pwd)/aarch64-linux-musl-cross/bin" >> $GITHUB_PATH
 
       - name: Build and tarball
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,7 +159,8 @@ jobs:
 
       - name: Install MUSL toolchain for AArch64
         run: |
-          wget -q https://musl.cc/aarch64-linux-musl-cross.tgz
+          curl -L --retry 3 --retry-delay 5 --fail -o aarch64-linux-musl-cross.tgz \
+            https://musl.cc/aarch64-linux-musl-cross.tgz
           tar -xf aarch64-linux-musl-cross.tgz
           echo "$(pwd)/aarch64-linux-musl-cross/bin" >> $GITHUB_PATH
 

--- a/crates/fta/src/output/mod.rs
+++ b/crates/fta/src/output/mod.rs
@@ -39,6 +39,8 @@ pub fn generate_output(
             let mut table = Table::new();
             table.load_preset(UTF8_FULL);
             table.set_content_arrangement(comfy_table::ContentArrangement::Dynamic);
+            table.force_no_tty();
+            table.set_width(80);
             table.set_header(vec![
                 "File",
                 "Num. lines",

--- a/crates/fta/src/parse/mod.rs
+++ b/crates/fta/src/parse/mod.rs
@@ -29,7 +29,7 @@ pub fn parse_module(
 
     let ts_config = TsConfig {
         tsx: use_tsx,
-        decorators: false,
+        decorators: true,
         dts: false,
         no_early_errors: false,
         disallow_ambiguous_jsx_like: true,

--- a/crates/fta/src/parse/tests.rs
+++ b/crates/fta/src/parse/tests.rs
@@ -66,4 +66,20 @@ mod tests {
         assert!(parsed_module.is_ok(), "Failed to parse TypeScript code");
         assert_eq!(line_count, 10, "Incorrect line count");
     }
+
+    #[test]
+    fn it_parses_decorators() {
+        let ts_code = r#"
+            import { IsNumber, IsOptional } from 'class-validator';
+
+            export class RulesReward {
+                @IsNumber()
+                @IsOptional()
+                points?: number;
+            }
+        "#;
+
+        let (parsed_module, _line_count) = parse_module(ts_code, true, false);
+        assert!(parsed_module.is_ok(), "Failed to parse decorators");
+    }
 }


### PR DESCRIPTION
## Summary

- enable decorator parsing in TypeScript parser (#140)
- use stable table width for output
- add test for decorator parsing

## Testing
- `cargo test -q`

------
https://chatgpt.com/codex/tasks/task_e_687d3cf5fed483308f89a5e65e6db087